### PR TITLE
Remove ext-xdebug check, add php-7.3 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "php": ">=7.0"
     },
     "require-dev": {
-        "ext-xdebug": "*",
         "phpunit/phpunit": "^6.0"
     },
     "autoload": {


### PR DESCRIPTION
# Changed log
- It's related to issue #7.
- I think it's fine to remove `ext-xdebug` check because this extension is required when `PHPUnit` need to generate the coverage report.
In Travis CI build, the `phpunit` command just do the unit test work, not generating code coverage report.
- It will be worked fine in the latest Travis CI build.
- According to this [issue discussion thread](https://github.com/travis-ci/travis-ci/issues/1236), the `php-nightly` version is not loaded the `XDebug` extension in Travis CI build.
- Also, add the `php-7.3` test during Travis CI build because this PHP version is stable.