### PR TITLE
EOL old runtimes from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.0
-    - 7.1
     - 7.2
     - 7.3
     - 7.4
@@ -12,8 +10,6 @@ matrix:
     fast_finish: true
     allow_failures:
         - php: nightly
-        - php: 7.0
-        - php: 7.1
 
 before_script:
   - composer update

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Utilities for dealing with file extensions",
     "type": "library",
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.2"
     },
     "require-dev": {
         "ext-xdebug": "*",


### PR DESCRIPTION
This removes unsupported upstream PHP runtimes

https://www.php.net/supported-versions.php

|Branch|Initial Release|Active Support Until|Security Support Until|
|-------|---------------|-----------------------|------------------------|
|7.2|30 Nov 2017 2 years, 5 months ago|30 Nov 2019 5 months ago|30 Nov 2020 in 6 months|
|7.3|6 Dec 2018 1 year, 4 months ago|6 Dec 2020 in 7 months|6 Dec 2021 in 1 year, 7 months|
|7.4|28 Nov 2019 5 months ago|28 Nov 2021 in 1 year, 6 months|28 Nov 2022 in 2 years, 6 months|
